### PR TITLE
Use number functions not reals

### DIFF
--- a/json2avro.c
+++ b/json2avro.c
@@ -170,21 +170,21 @@ int schema_traverse(const avro_schema_t schema, json_t *json, json_t *dft,
         break;
 
     case AVRO_FLOAT:
-        if (!json_is_real(json)) {
+        if (!json_is_number(json)) {
             if (!quiet)
-                fprintf(stderr, "ERROR: Expecting JSON real for Avro float, got something else\n");
+                fprintf(stderr, "ERROR: Expecting JSON number for Avro float, got something else\n");
             return 1;
         }
-        avro_value_set_float(current_val, json_real_value(json));
+        avro_value_set_float(current_val, json_number_value(json));
         break;
 
     case AVRO_DOUBLE:
-        if (!json_is_real(json)) {
+        if (!json_is_number(json)) {
             if (!quiet)
-                fprintf(stderr, "ERROR: Expecting JSON real for Avro double, got something else\n");
+                fprintf(stderr, "ERROR: Expecting JSON number for Avro double, got something else\n");
             return 1;
         }
-        avro_value_set_double(current_val, json_real_value(json));
+        avro_value_set_double(current_val, json_number_value(json));
         break;
 
     case AVRO_BOOLEAN:


### PR DESCRIPTION
In JSON integers are a subset of the reals; but the use of json_is_real and json_real_value means that
other JSON serialization libraries have to be aware that (for example) 0 must be formatted as 0.0 for
this code to process it correctly. Using the _number functions means that for example, this works:

```
echo '{"a_float":1}'|./json2avro -s '{"type":"record","name":"testrec","fields":[{"name":"a_float","type":"int"}]}' - >/dev/null
```
